### PR TITLE
EASY-1055: Get depositorId from deposit.properties rather than from c…

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/ingest_flow/Execution.scala
+++ b/src/main/scala/nl/knaw/dans/easy/ingest_flow/Execution.scala
@@ -61,9 +61,8 @@ trait Execution {
     }
 
     EasyStageDataset.run(stage.Settings(
-      ownerId = s.ownerId,
       submissionTimestamp = getSubmissionTimestamp,
-      bagitDir = bagDir.get,
+      depositDir = s.depositDir,
       sdoSetDir = s.sdoSetDir,
       URN = urn,
       DOI = doi,


### PR DESCRIPTION
fixes EASY-1055

#### When applied it will
* depositDir (instead of bagitDir) is passed to EasyStageDataset

#### Where should the reviewer @DANS-KNAW/easy start?
Only Execution.scala
#### How should this be manually tested?
mvn clean install
#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-stage-dataset | [81#](https://github.com/DANS-KNAW/easy-stage-dataset/pull/81) 
